### PR TITLE
Fixed a bug where an infinite loop would occur when getting a random idea

### DIFF
--- a/src/DateNight.Api/appsettings.Development.json
+++ b/src/DateNight.Api/appsettings.Development.json
@@ -1,7 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Trace",
       "Microsoft.AspNetCore": "Warning"
     }
   }

--- a/src/DateNight.App/Pages/RandomIdea.razor.cs
+++ b/src/DateNight.App/Pages/RandomIdea.razor.cs
@@ -26,11 +26,18 @@ public partial class RandomIdea
     {
         _idea = null;
 
+        int loopCount = 1;
+
         do
         {
             // We don't want to display the same idea twice.
+            // If we get the same idea 3 times in a row, it probably means there
+            // is only 1 idea left in the collection.
+
             _idea = await DateNightApiClient.GetRandomIdeaAsync();
-        } while (_idea.Id == _previousRandomIdeaId);
+
+            loopCount++;
+        } while (_idea.Id == _previousRandomIdeaId && loopCount < 3);
 
         _previousRandomIdeaId = _idea.Id;
     }

--- a/src/DateNight.Core/Interfaces/IAppLogger.cs
+++ b/src/DateNight.Core/Interfaces/IAppLogger.cs
@@ -2,6 +2,8 @@
 
 public interface IAppLogger<T>
 {
+    void LogDebug(string? message, params object[] args);
+
     void LogError(string? message, params object[] args);
 
     void LogInformation(string? message, params object[] args);

--- a/src/DateNight.Core/Services/IdeaService.cs
+++ b/src/DateNight.Core/Services/IdeaService.cs
@@ -102,14 +102,19 @@ public class IdeaService : IIdeaService
 
     public async Task<Idea> GetRandomIdeaAsync()
     {
-        _logger.LogInformation("Getting random idea");
+        _logger.LogInformation("({method}) Getting random idea", nameof(GetRandomIdeaAsync));
 
         var ideas = await GetAllIdeasInternalAsync();
         var nonActiveIdeas = ideas.Where(idea => idea.State != IdeaState.Active);
 
         int numIdeas = nonActiveIdeas.Count();
+        _logger.LogDebug("({method}) Total number of non-active ideas: {numIdeas}", nameof(GetRandomIdeaAsync), numIdeas);
+
         int randomIndex = numIdeas > 1 ? _random.Next(0, numIdeas) : 0;
+        _logger.LogDebug("({method}) Random index chosen: {randomIndex}", nameof(GetRandomIdeaAsync), randomIndex);
+
         Idea idea = nonActiveIdeas.ElementAt(randomIndex);
+        _logger.LogInformation("({method}) Returning random idea '{Id}'", nameof(GetRandomIdeaAsync), idea.Id!);
 
         return idea;
     }

--- a/src/DateNight.Infrastructure/Logging/LoggerAdapter.cs
+++ b/src/DateNight.Infrastructure/Logging/LoggerAdapter.cs
@@ -12,6 +12,11 @@ public class LoggerAdapter<T> : IAppLogger<T>
         _logger = loggerFactory.CreateLogger<T>();
     }
 
+    public void LogDebug(string? message, params object[] args)
+    {
+        _logger.LogDebug(message, args);
+    }
+
     public void LogError(string? message, params object[] args)
     {
         _logger.LogError(message, args);


### PR DESCRIPTION
When the random idea collection drops below 2 ideas, the same idea is returned from the get random idea API call. This was causing an infinite loop on the Random Idea page which would continuously call the API if the idea did not change.

Closes #46